### PR TITLE
샵 등록

### DIFF
--- a/src/main/java/com/kosta/catdog/controller/ShopController.java
+++ b/src/main/java/com/kosta/catdog/controller/ShopController.java
@@ -1,6 +1,7 @@
 package com.kosta.catdog.controller;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -13,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.servlet.http.HttpServletResponse;
 
 @RestController
 public class ShopController {
@@ -83,6 +86,7 @@ public class ShopController {
 
 		try{
 		Shop shop = new Shop();
+		shop.setId(id);
 		shop.setName(name);
 		shop.setSId(sId);
 		shop.setAddressRoad(address_road);
@@ -116,6 +120,32 @@ public class ShopController {
 	// 메뉴 등록 
 	public void regshopmenu(String menu) {
 		System.out.println("regShopMenu !!");
+	}
+
+
+	// 샵 조회
+	@GetMapping("/shoplist")
+	public List<Shop> shoplist(String id){
+		System.out.println("Shop List !!!");
+		System.out.println("Id : " + id);
+		try{
+			List<Shop> sl =  shopService.listshop(id);
+			System.out.println("Shop Info : " + sl);
+			return sl != null ? sl : Collections.emptyList();
+		}catch (Exception e){
+			e.printStackTrace();
+			return Collections.emptyList();
+		}
+	}
+
+
+	@GetMapping("/shopimg/{num}")
+	public void ImageView(@PathVariable Integer num, HttpServletResponse response) {
+		try {
+			shopService.fileView(num, response.getOutputStream());
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
 	}
 
 }

--- a/src/main/java/com/kosta/catdog/entity/Shop.java
+++ b/src/main/java/com/kosta/catdog/entity/Shop.java
@@ -27,7 +27,8 @@ public class Shop {
 	private Integer num; // 고유번호
 	@Column(unique=true)
 	private Integer sId; // 사업자 등록번호
-	@Column(unique=true)
+//	@Column(unique=true)
+	@Column
 	private String id;
 	@Column
 	private String name;

--- a/src/main/java/com/kosta/catdog/repository/ShopDslRepository.java
+++ b/src/main/java/com/kosta/catdog/repository/ShopDslRepository.java
@@ -1,0 +1,27 @@
+package com.kosta.catdog.repository;
+
+import com.kosta.catdog.entity.QShop;
+import com.kosta.catdog.entity.Shop;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+
+@Repository
+public class ShopDslRepository {
+    @Autowired
+    private JPAQueryFactory jpaQueryFactory;
+
+    @Autowired
+    EntityManager entityManager;
+
+    // Shop
+    public List<Shop> findById(String id){
+        QShop shop = QShop.shop;
+        return jpaQueryFactory.selectFrom(shop)
+                .where(shop.id.eq(id)).fetch();
+    }
+}

--- a/src/main/java/com/kosta/catdog/service/ShopService.java
+++ b/src/main/java/com/kosta/catdog/service/ShopService.java
@@ -1,5 +1,6 @@
 package com.kosta.catdog.service;
 
+import java.io.OutputStream;
 import java.util.List;
 
 import com.kosta.catdog.entity.Designer;
@@ -21,5 +22,11 @@ public interface ShopService {
 	void addShopNotice(String notice) throws Exception;
 	// 소속 디자이너 모아 보여주기
 	List<Designer> designerListByShop(Integer num) throws Exception;
+
+	// 샵 조회
+	List<Shop> listshop(String id) throws Exception;
+
+	// 샵 이미지 조회
+	void fileView(Integer num, OutputStream out) throws Exception ;
 	
 }

--- a/src/main/java/com/kosta/catdog/service/ShopServiceImpl.java
+++ b/src/main/java/com/kosta/catdog/service/ShopServiceImpl.java
@@ -1,17 +1,21 @@
 package com.kosta.catdog.service;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.OutputStream;
 import java.sql.Date;
 import java.time.LocalDate;
 import java.util.List;
 
 import com.kosta.catdog.entity.*;
+import com.kosta.catdog.repository.ShopDslRepository;
 import com.kosta.catdog.repository.ShopFileVORepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.kosta.catdog.repository.ShopRepository;
 import com.kosta.catdog.repository.UserDslRepository;
+import org.springframework.util.FileCopyUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -21,6 +25,9 @@ public class ShopServiceImpl implements ShopService {
 	private UserDslRepository userDslRepository;
 	@Autowired
 	private ShopRepository shopRepository;
+
+	@Autowired
+	private ShopDslRepository shopDslRepository;
 
 	@Autowired
 	private ShopFileVORepository shopFileVORepository;
@@ -83,6 +90,30 @@ public class ShopServiceImpl implements ShopService {
 	public List<Designer> designerListByShop(Integer num) throws Exception {
 		// TODO Auto-generated method stub
 		return null;
+	}
+
+	@Override
+	public List<Shop> listshop(String id) throws Exception {
+		return shopDslRepository.findById(id);
+	}
+
+	@Override
+	public void fileView(Integer num, OutputStream out) throws Exception {
+		try {
+//			Optional<PetFileVO> fileVoOptional  = petFileVORepository.findById(num);
+//			PetFileVO fileVo = fileVoOptional.get();
+
+//			FileCopyUtils.copy(fileVo.getData(), out); //데이타 뿌려주기
+//			FileInputStream fis = new FileInputStream(fileVo.getDir()+num);//폴더에서 가져오기
+
+			String dir = "/Users/baghaengbog/Desktop/Study/upload/shop";
+			FileInputStream fis = new FileInputStream(dir+num);
+			FileCopyUtils.copy(fis, out);
+			out.flush();
+
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
 	}
 
 }


### PR DESCRIPTION
1. 샵 등록시 사업자 번호와 등록하는 유저의 id를 샵 테이블에 같이 넣어줌
2. 다중 샵 등록시 id 컬럼이 중복이 되어 오류가 발생하여 id의 unique 속성 제거
3. 샵 조회 쿼리 작성
4. 샵 조회 , 이미지 조회 서비스